### PR TITLE
Removing React SDK menu entry from dev tools menu

### DIFF
--- a/_templates/navbar-nav.html
+++ b/_templates/navbar-nav.html
@@ -19,9 +19,6 @@
                <li class="nav-item ">
                   <a href="https://docs.inrupt.com/developer-tools/javascript/client-libraries/">JavaScript Client Libraries</a>
                </li>
-               <li class="nav-item ">
-                  <a href="https://docs.inrupt.com/developer-tools/javascript/react-sdk/">Solid React SDK</a>
-               </li>
             </div>
          </div>
          <li class="nav-item">


### PR DESCRIPTION
Removing React SDK menu entry from dev tools menu